### PR TITLE
Feature: add logging specific messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-codec"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 description = "Encoding and decoding primitives for waSCC (WebAssembly Secure Capabilities Connector)"
@@ -20,4 +20,5 @@ serde = "1.0.104"
 serde_json = "1.0.48"
 serde_derive = "1.0.104"
 rmp-serde = "0.14.3"
+log = { version="0.4.8", features =["std","serde"]}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 
 #[macro_use]
 extern crate serde_derive;
+extern crate log;
 
 extern crate rmp_serde as rmps;
 use rmps::{Deserializer, Serializer};
@@ -53,3 +54,4 @@ pub mod extras;
 pub mod http;
 pub mod keyvalue;
 pub mod messaging;
+pub mod logging;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,17 @@
+//! # Logging Data Types
+//!
+//! This module contains data types for the `wascc:logging` capability provider
+//! The message set is intentionally a mirror of the log crate's types.
+
+pub const OP_LOG: &str = "Log";
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+/// A representation of a log message
+pub struct LogRequest {
+    /// A string which represents the module or source of the log message
+    pub target: String,
+    /// level corresponds to the log crate's Level enum where Error = 1 and Trace = 5
+    pub level: usize,
+    /// A string that represents the body of the log message
+    pub body: String,
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,15 +1,14 @@
 //! # Logging Data Types
 //!
 //! This module contains data types for the `wascc:logging` capability provider
-//! The message set is intentionally a mirror of the log crate's types.
 
-pub const OP_LOG: &str = "Log";
+pub const OP_LOG: &str = "WriteLog";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
-/// A representation of a log message
-pub struct LogRequest {
-    /// A string which represents the module or source of the log message
-    pub target: String,
+/// A representation of a request to write a log entry
+pub struct WriteLogRequest {
+    /// A string which represents the actor source of the log message
+    pub actor: String,
     /// level corresponds to the log crate's Level enum where Error = 1 and Trace = 5
     pub level: usize,
     /// A string that represents the body of the log message

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -9,7 +9,9 @@ pub const OP_LOG: &str = "WriteLog";
 pub struct WriteLogRequest {
     /// A string which represents the actor source of the log message
     pub actor: String,
-    /// level corresponds to the log crate's Level enum where Error = 1 and Trace = 5
+    /// level corresponds to the log level 
+    ///
+    /// "OFF"=0 , "ERROR"=1, "WARN"=2, "INFO"=3, "DEBUG"=4, "TRACE"=5
     pub level: usize,
     /// A string that represents the body of the log message
     pub body: String,


### PR DESCRIPTION
This change adds a `Log` operation and a `LogRequest` message.  It intentionally does not include baggage or other metadata which will be added as part of the log body by the actor sdk.