### PR TITLE
Closes #11.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-codec"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 description = "Encoding and decoding primitives for waSCC (WebAssembly Secure Capabilities Connector)"
@@ -16,17 +16,17 @@ maintenance = { status = "actively-developed"}
 
 
 [dependencies]
-serde = "1.0.105"
-serde_json = "1.0.50"
-serde_derive = "1.0.105"
-serde_bytes = "0.11.3"
+serde = "1.0.111"
+serde_json = "1.0.53"
+serde_derive = "1.0.111"
+serde_bytes = "0.11.4"
 rmp-serde = "0.14.3"
 log = { version="0.4.8", features =["std","serde"]}
 
 [dev-dependencies]
-structopt = "0.3.12"
-serde_json = "1.0.50"
-base64 = "0.12.0"
+structopt = "0.3.14"
+serde_json = "1.0.53"
+base64 = "0.12.1"
 
 [[example]]      
 name = "codectest" 

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -18,8 +18,8 @@ use std::error::Error;
 
 use std::any::Any;
 
-/// Portable capability providers must respond to this operation with a messagepack-serialized
-/// `CapabilityDescriptor` value, whereas native providers implement a method via the provider trait
+/// All capability providers must respond to this operation, which will be requested by
+/// the host (the `system` actor)
 pub const OP_GET_CAPABILITY_DESCRIPTOR: &str = "GetCapabilityDescriptor";
 
 /// The dispatcher is used by a native capability provider to send commands to an actor module, expecting
@@ -178,8 +178,6 @@ pub trait CapabilityProvider: Any + Send + Sync {
     /// This function will be called on the provider when the host runtime is ready and has configured a dispatcher. This function is only ever
     /// called _once_ for a capability provider, regardless of the number of actors being managed in the host
     fn configure_dispatch(&self, dispatcher: Box<dyn Dispatcher>) -> Result<(), Box<dyn Error>>;
-    /// Obtains a descriptor that describes the capability provider and the operations it supports
-    fn get_descriptor(&self) -> Result<CapabilityDescriptor, Box<dyn Error>>;
     /// Invoked when an actor has requested that a provider perform a given operation
     fn handle_call(&self, actor: &str, op: &str, msg: &[u8]) -> Result<Vec<u8>, Box<dyn Error>>;
 }

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -18,10 +18,141 @@ use std::error::Error;
 
 use std::any::Any;
 
+/// Portable capability providers must respond to this operation with a messagepack-serialized
+/// `CapabilityDescriptor` value, whereas native providers implement a method via the provider trait
+pub const OP_GET_CAPABILITY_DESCRIPTOR: &str = "GetCapabilityDescriptor";
+
 /// The dispatcher is used by a native capability provider to send commands to an actor module, expecting
 /// a result containing a byte array in return
 pub trait Dispatcher: Any + Send + Sync {
     fn dispatch(&self, actor: &str, op: &str, msg: &[u8]) -> Result<Vec<u8>, Box<dyn Error>>;
+}
+
+/// Metadata describing the capability provider and the operations it supports
+#[repr(C)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct CapabilityDescriptor {
+    /// The capability ID of the provider, e.g. `wascc:messaging` or `thirdparty:someprovider`
+    pub id: String,
+    /// The human-friendly name of the provider, displayed in short messages and log entries
+    pub name: String,
+    /// A semver string representing the version of the provider module
+    pub version: String,
+    /// A monotonicaly increasing revision number
+    pub revision: u32,
+    /// A longer, documentation-friendly, description of this provider
+    pub long_description: String,
+    /// A list of all of the operations supported by this provider
+    pub supported_operations: Vec<OperationDescriptor>,
+}
+
+impl CapabilityDescriptor {
+    pub fn builder() -> CapabilityDescriptorBuilder {
+        CapabilityDescriptorBuilder::new()
+    }
+}
+
+#[derive(Default)]
+pub struct CapabilityDescriptorBuilder {
+    descriptor: CapabilityDescriptor,
+}
+
+impl CapabilityDescriptorBuilder {
+    fn new() -> CapabilityDescriptorBuilder {
+        CapabilityDescriptorBuilder::default()
+    }
+
+    pub fn id(self, id: &str) -> Self {
+        CapabilityDescriptorBuilder {
+            descriptor: CapabilityDescriptor {
+                id: id.to_string(),
+                ..self.descriptor
+            },
+        }
+    }
+
+    pub fn name(self, name: &str) -> Self {
+        CapabilityDescriptorBuilder {
+            descriptor: CapabilityDescriptor {
+                name: name.to_string(),
+                ..self.descriptor
+            },
+        }
+    }
+
+    pub fn long_description(self, desc: &str) -> Self {
+        CapabilityDescriptorBuilder {
+            descriptor: CapabilityDescriptor {
+                long_description: desc.to_string(),
+                ..self.descriptor
+            },
+        }
+    }
+
+    pub fn version(self, ver: &str) -> Self {
+        CapabilityDescriptorBuilder {
+            descriptor: CapabilityDescriptor {
+                version: ver.to_string(),
+                ..self.descriptor
+            },
+        }
+    }
+
+    pub fn revision(self, rev: u32) -> Self {
+        CapabilityDescriptorBuilder {
+            descriptor: CapabilityDescriptor {
+                revision: rev,
+                ..self.descriptor
+            },
+        }
+    }
+
+    pub fn with_operation(self, name: &str, direction: OperationDirection, doctext: &str) -> Self {
+        let mut newops = self.descriptor.supported_operations;
+        newops.push(OperationDescriptor::new(name, direction, doctext));
+        CapabilityDescriptorBuilder {
+            descriptor: CapabilityDescriptor {
+                supported_operations: newops,
+                ..self.descriptor
+            },
+        }
+    }
+
+    pub fn build(self) -> CapabilityDescriptor {
+        self.descriptor
+    }
+}
+
+/// A description of a single operation supported by a capability provider
+#[repr(C)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OperationDescriptor {
+    /// The name of the operation. This must be unique per capability ID
+    pub name: String,
+    /// Indicates the direction of the operation (can be bi-directional)
+    pub direction: OperationDirection,
+    /// Documentation-suitable text for this operation
+    pub doctext: String,
+}
+
+impl OperationDescriptor {
+    pub fn new(name: &str, direction: OperationDirection, doctext: &str) -> OperationDescriptor {
+        OperationDescriptor {
+            name: name.to_string(),
+            direction,
+            doctext: doctext.to_string(),
+        }
+    }
+}
+
+/// Represents the direction of an operation invocation
+#[repr(C)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationDirection {
+    ToActor,
+    ToProvider,
+    Both,
 }
 
 /// The NullDispatcher is as its name implies--a dispatcher that does nothing. This is convenient for
@@ -47,12 +178,9 @@ pub trait CapabilityProvider: Any + Send + Sync {
     /// This function will be called on the provider when the host runtime is ready and has configured a dispatcher. This function is only ever
     /// called _once_ for a capability provider, regardless of the number of actors being managed in the host
     fn configure_dispatch(&self, dispatcher: Box<dyn Dispatcher>) -> Result<(), Box<dyn Error>>;
-    /// The capability provider will return either one of the well-known capability IDs or a custom capability ID using `namespace:id` notation
-    fn capability_id(&self) -> &'static str;
-    /// The human-readable, friendly name of this capability provider. By convention, the provider should include information about
-    /// the specific implementation, e.g. contain the name "Redis" for a K/V store or "NATS" for a message broker.
-    fn name(&self) -> &'static str;
-    /// This function is called by the host runtime when an actor module requests an operation be executed by the capability provider
+    /// Obtains a descriptor that describes the capability provider and the operations it supports
+    fn get_descriptor(&self) -> Result<CapabilityDescriptor, Box<dyn Error>>;
+    /// Invoked when an actor has requested that a provider perform a given operation
     fn handle_call(&self, actor: &str, op: &str, msg: &[u8]) -> Result<Vec<u8>, Box<dyn Error>>;
 }
 
@@ -70,4 +198,26 @@ macro_rules! capability_provider {
             Box::into_raw(boxed)
         }
     };
+}
+
+#[cfg(test)]
+mod test {
+    use super::{CapabilityDescriptor, OperationDescriptor, OperationDirection};
+    #[test]
+    fn descriptor_certify_desired_json_format() {
+        let d = CapabilityDescriptor {
+            name: "test".to_string(),
+            id: "wascc:testing".to_string(),
+            version: "0.0.1".to_string(),
+            revision: 1,
+            long_description: "this is a test".to_string(),
+            supported_operations: vec![OperationDescriptor {
+                direction: OperationDirection::ToActor,
+                doctext: "this is a test".to_string(),
+                name: "OperationDumboDrop".to_string(),
+            }],
+        };
+        let s = serde_json::to_string(&d).unwrap();
+        assert_eq!(s, "{\"id\":\"wascc:testing\",\"name\":\"test\",\"version\":\"0.0.1\",\"revision\":1,\"long_description\":\"this is a test\",\"supported_operations\":[{\"name\":\"OperationDumboDrop\",\"direction\":\"to_actor\",\"doctext\":\"this is a test\"}]}".to_string());
+    }
 }

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -52,16 +52,19 @@ impl CapabilityDescriptor {
     }
 }
 
+/// A fluent syntax builder for creating a capability descriptor
 #[derive(Default)]
 pub struct CapabilityDescriptorBuilder {
     descriptor: CapabilityDescriptor,
 }
 
 impl CapabilityDescriptorBuilder {
+    /// Creates a new capability descriptor builder
     fn new() -> CapabilityDescriptorBuilder {
         CapabilityDescriptorBuilder::default()
     }
 
+    /// Sets the capability ID (e.g. `wascc:messaging`) of the provider
     pub fn id(self, id: &str) -> Self {
         CapabilityDescriptorBuilder {
             descriptor: CapabilityDescriptor {
@@ -71,6 +74,7 @@ impl CapabilityDescriptorBuilder {
         }
     }
 
+    /// Sets the name of the capability provider.
     pub fn name(self, name: &str) -> Self {
         CapabilityDescriptorBuilder {
             descriptor: CapabilityDescriptor {
@@ -80,6 +84,7 @@ impl CapabilityDescriptorBuilder {
         }
     }
 
+    /// Sets a longer, documentation-friendly description of the provider
     pub fn long_description(self, desc: &str) -> Self {
         CapabilityDescriptorBuilder {
             descriptor: CapabilityDescriptor {
@@ -89,6 +94,7 @@ impl CapabilityDescriptorBuilder {
         }
     }
 
+    /// Sets the version string (semver by convention) of the provider
     pub fn version(self, ver: &str) -> Self {
         CapabilityDescriptorBuilder {
             descriptor: CapabilityDescriptor {
@@ -98,6 +104,7 @@ impl CapabilityDescriptorBuilder {
         }
     }
 
+    /// Sets the monotonically increasing, numeric revision number of a provider. Used when comparing provider versions
     pub fn revision(self, rev: u32) -> Self {
         CapabilityDescriptorBuilder {
             descriptor: CapabilityDescriptor {
@@ -107,6 +114,7 @@ impl CapabilityDescriptorBuilder {
         }
     }
 
+    /// Adds an operation descriptor to the provider descriptor.
     pub fn with_operation(self, name: &str, direction: OperationDirection, doctext: &str) -> Self {
         let mut newops = self.descriptor.supported_operations;
         newops.push(OperationDescriptor::new(name, direction, doctext));
@@ -118,6 +126,7 @@ impl CapabilityDescriptorBuilder {
         }
     }
 
+    /// Produces a new capability descriptor from the builder's configuration
     pub fn build(self) -> CapabilityDescriptor {
         self.descriptor
     }
@@ -136,6 +145,7 @@ pub struct OperationDescriptor {
 }
 
 impl OperationDescriptor {
+    /// Creates a new operation descriptor
     pub fn new(name: &str, direction: OperationDirection, doctext: &str) -> OperationDescriptor {
         OperationDescriptor {
             name: name.to_string(),
@@ -157,7 +167,7 @@ pub enum OperationDirection {
 
 /// The NullDispatcher is as its name implies--a dispatcher that does nothing. This is convenient for
 /// initializing a capability provider with a null dispatcher, and then swapping it for a real dispatcher
-/// when the host runtime provides one tethered with the appropriate channels
+/// when the host runtime provides one configured with the appropriate channels
 #[derive(Default)]
 pub struct NullDispatcher {}
 
@@ -173,7 +183,8 @@ impl Dispatcher for NullDispatcher {
     }
 }
 
-/// Every capability provider must implement this trait
+/// Every native capability provider must implement this trait. Both portable and native capability providers
+/// must respond to the following operations: `OP_BIND_ACTOR`, `OP_REMOVE_ACTOR`, `OP_GET_CAPABILITY_DESCRIPTOR`
 pub trait CapabilityProvider: Any + Send + Sync {
     /// This function will be called on the provider when the host runtime is ready and has configured a dispatcher. This function is only ever
     /// called _once_ for a capability provider, regardless of the number of actors being managed in the host


### PR DESCRIPTION
Initial implementation of the new capability provider contract.
Decided to use a function that can fail rather than exposing a constant,
because constant functions in Rust can't do things like invoke
builders for fluid syntax.
Also closes #8 